### PR TITLE
Fix: Remove erroneous pnpm export command from build workflow

### DIFF
--- a/.github/workflows/v0-bu-e-fa-fire-retardant-build.yaml
+++ b/.github/workflows/v0-bu-e-fa-fire-retardant-build.yaml
@@ -40,7 +40,6 @@ jobs:
           npm install --global pnpm
           pnpm install
           pnpm build
-          pnpm export
 
 # Please do not touch the following action
       - name: Store deployment content


### PR DESCRIPTION
The `pnpm export` command is not a valid script in `package.json` and was causing the build to fail.

The project is configured with `output: 'export'` in `next.config.mjs`, which means `pnpm build` (aliasing `next build`) already handles the static export of the application.

This commit removes the unnecessary and incorrect `pnpm export` command from the build workflow file `.github/workflows/v0-bu-e-fa-fire-retardant-build.yaml`.