### PR TITLE
fix(ci): remove invalid 'pnpm export' command

### DIFF
--- a/.github/workflows/v0-bu-e-fa-fire-retardant-build.yaml
+++ b/.github/workflows/v0-bu-e-fa-fire-retardant-build.yaml
@@ -40,7 +40,6 @@ jobs:
           npm install --global pnpm
           pnpm install
           pnpm build
-          pnpm export
 
 # Please do not touch the following action
       - name: Store deployment content


### PR DESCRIPTION
The 'pnpm export' command was causing the build to fail as it is not a valid pnpm command. This commit removes the line from the build workflow to resolve the error.